### PR TITLE
Rename clusterAddress as tunnelAddress

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -18,7 +18,7 @@ describe("TunnelServer", () => {
   let server: TunnelServer;
   const port = 51515;
   const secret = "doubleouseven";
-  const clusterAddress = "http://localhost/bored/a026e50d-f9b4-4aa8-ba02-c9722f7f0663";
+  const tunnelAddress = "http://localhost/bored/a026e50d-f9b4-4aa8-ba02-c9722f7f0663";
 
   /**
    * {
@@ -44,7 +44,7 @@ describe("TunnelServer", () => {
 
   beforeEach(async () => {
     server = new TunnelServer();
-    await server.start(port, "", idpPublicKey, clusterAddress);
+    await server.start(port, "", idpPublicKey, tunnelAddress);
   });
 
   afterEach(() => {
@@ -157,7 +157,7 @@ describe("TunnelServer", () => {
       it("accepts agent connection with shared-secret authorization header", async () => {
         server.stop();
         server = new TunnelServer();
-        await server.start(port, secret, idpPublicKey, clusterAddress);
+        await server.start(port, secret, idpPublicKey, tunnelAddress);
 
         const connect = () => {
           return incomingSocket("agent", {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,13 +16,13 @@ export class TunnelServer {
 
   public agentToken = "";
   public idpPublicKey = "";
-  public clusterAddress?: string;
+  public tunnelAddress?: string;
   public agents: Map<ClusterId, Agent[]> = new Map();
 
-  start(port = 8080, agentToken: string, idpPublicKey: string, clusterAddress = process.env.CLUSTER_ADDRESS || ""): Promise<void> {
+  start(port = 8080, agentToken: string, idpPublicKey: string, tunnelAddress = process.env.TUNNEL_ADDRESS || ""): Promise<void> {
     this.agentToken = agentToken;
     this.idpPublicKey = idpPublicKey;
-    this.clusterAddress = clusterAddress;
+    this.tunnelAddress = tunnelAddress;
 
     this.ws = new Server({
       noServer: true

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,7 +28,7 @@ export function parseAuthorization(authHeader: string) {
 export function verifyClientToken(token: string, server: TunnelServer) {
   return jwt.verify(token, server.idpPublicKey, {
     algorithms: ["RS256", "RS384", "RS512"],
-    audience: server.clusterAddress
+    audience: server.tunnelAddress
   }) as ClientTokenData;
 }
 
@@ -36,6 +36,6 @@ export function verifyClientToken(token: string, server: TunnelServer) {
 export function verifyAgentToken(token: string, server: TunnelServer) {
   return jwt.verify(token, server.idpPublicKey, {
     algorithms: ["RS256", "RS384", "RS512"],
-    audience: server.clusterAddress
+    audience: server.tunnelAddress
   }) as AgentTokenData;
 }


### PR DESCRIPTION
This PR will rename `clusterAddress` as `tunnelAddress` since the bored server is multi-tenant and the address is not cluster specific anymore.