### PR TITLE
Remove legacy handling of /client/public-key

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -107,22 +107,6 @@ describe("TunnelServer", () => {
       expect(res.body).toBe(idpPublicKey);
     });
 
-    it("responds 200 on /client/public-key without token if agent is connected", async () => {
-      const ws = {
-        once: jest.fn(),
-        on: jest.fn()
-      };
-
-      const agents = server.getAgentsForClusterId("default");
-
-      agents.push(new Agent(ws as any, "rsa-public-key"));
-
-      const res = await get("/client/public-key");
-
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toBe("rsa-public-key");
-    });
-
     it("responds 200 on /client/public-key with token if agent is connected", async () => {
       const ws = {
         once: jest.fn(),
@@ -139,13 +123,13 @@ describe("TunnelServer", () => {
       expect(res.body).toBe("rsa-public-key");
     });
 
-    it("responds 404 on /client/public-key without token if agent is not connected", async () => {
+    it("responds 403 on /client/public-key without token if agent is not connected", async () => {
       const res = await get("/client/public-key");
 
-      expect(res.statusCode).toBe(404);
+      expect(res.statusCode).toBe(403);
     });
 
-    it("responds 404 on /client/public-key without token if agent is not connected", async () => {
+    it("responds 404 on /client/public-key with token if agent is not connected", async () => {
       const res = await get("/client/public-key", { "Authorization": `Bearer ${jwtToken}`});
 
       expect(res.statusCode).toBe(404);

--- a/src/request-handlers/client-public-key.ts
+++ b/src/request-handlers/client-public-key.ts
@@ -1,16 +1,10 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { Agent } from "../agent";
-import { defaultClusterId, TunnelServer } from "../server";
+import { TunnelServer } from "../server";
 import { parseAuthorization, verifyClientToken } from "../util";
 
 export function handleClientPublicKey(req: IncomingMessage, res: ServerResponse, server: TunnelServer) {
-  if (!req.headers.authorization) { // old agent
-    handleClientDefaultPublicKey(res, server);
-
-    return;
-  }
-
-  const authorization = parseAuthorization(req.headers.authorization);
+  const authorization = parseAuthorization(req?.headers?.authorization);
 
   if (!authorization || !authorization.token) {
     res.writeHead(403);
@@ -31,12 +25,6 @@ export function handleClientPublicKey(req: IncomingMessage, res: ServerResponse,
 
 
   return;
-}
-
-function handleClientDefaultPublicKey(res: ServerResponse, server: TunnelServer) {
-  const agents = server.getAgentsForClusterId(defaultClusterId);
-
-  respondWithAgentPublicKey(res, agents);
 }
 
 function respondWithAgentPublicKey(res: ServerResponse, agents: Agent[]) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,7 +12,11 @@ export type AgentTokenData = {
   aud: string;
 };
 
-export function parseAuthorization(authHeader: string) {
+export function parseAuthorization(authHeader?: string) {
+  if (!authHeader) {
+    return null;
+  }
+
   const authorization = authHeader.split(" ");
 
   if (authorization.length !== 2) {


### PR DESCRIPTION
Not tested e2e, but I believe we don't need this handling anymore.