### PR TITLE
Improve stream error handling

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,6 +19,16 @@ export class Agent {
     this.socket.on("close", () => {
       this.clients.forEach((client) => this.removeClient(client));
     });
+
+    stream.on("error", error => {
+      console.error(error);
+      this.clients.forEach((client) => this.removeClient(client));
+    });
+
+    this.mplex.on("error", error => {
+      console.error(error);
+      this.clients.forEach((client) => this.removeClient(client));
+    });
   }
 
   addClient(socket: WebSocket) {
@@ -37,7 +47,18 @@ export class Agent {
     const duplex = WebSocket.createWebSocketStream(socket);
 
     duplex.pipe(mplex).pipe(duplex);
+
     duplex.on("unpipe", () => {
+      socket.close(4410);
+    });
+
+    duplex.on("error", (error) => {
+      console.error(error);
+      socket.close(4410);
+    });
+
+    mplex.on("error", (error) => {
+      console.error(error);
       socket.close(4410);
     });
   }


### PR DESCRIPTION
We observed bored server crashing with the following stack trace:

```
events.js:292
throw er; // Unhandled 'error' event
^
Error: WebSocket is not open: readyState 2 (CLOSING)
at sendAfterClose (/app/node_modules/ws/lib/websocket.js:754:17)
at WebSocket.send (/app/node_modules/ws/lib/websocket.js:345:7)
at Duplex.duplex._write (/app/node_modules/ws/lib/stream.js:157:8)
at writeOrBuffer (internal/streams/writable.js:358:12)
at Duplex.Writable.write (internal/streams/writable.js:303:10)
at BoredMplex.ondata (internal/streams/readable.js:719:22)
at BoredMplex.emit (events.js:315:20)
at addChunk (internal/streams/readable.js:309:12)
at readableAddChunk (internal/streams/readable.js:284:9)
at BoredMplex.Readable.push (internal/streams/readable.js:223:10)
Emitted 'error' event on Duplex instance at:
at Duplex.duplexOnError (/app/node_modules/ws/lib/stream.js:37:10)
at Duplex.emit (events.js:327:22)
at emitErrorNT (internal/streams/destroy.js:106:8)
at errorOrDestroy (internal/streams/destroy.js:168:7)
at onwriteError (internal/streams/writable.js:391:3)
at processTicksAndRejections (internal/process/task_queues.js:82:21)
```

This is likely caused by streams lacking error handling, which means errors will be thrown which will then close the node process as unhandled exception.

This PR adds the missing error handling, which should enable the bored server to continue running and the agent + client will reconnect.

I tested this by connecting a "client" and bored-agent to it and emitting fake errors to `this.socket`, `stream`, `this.mplex`, `mplex` and `duplex`. The client and agent was able to reconnect after the errors - though I didn't setup a full e2e environment for testing this.