### PR TITLE
Do not send response multiple times on error

### DIFF
--- a/src/request-handlers/client-public-key.ts
+++ b/src/request-handlers/client-public-key.ts
@@ -19,11 +19,13 @@ export function handleClientPublicKey(req: IncomingMessage, res: ServerResponse,
 
     try {
       const tokenData = verifyClientToken(authorization?.token, server);
-      
+
       clusterId = tokenData.clusterId;
     } catch(error) {
       res.writeHead(403);
       res.end();
+
+      return;
     }
   }
 


### PR DESCRIPTION
If requesting client public key with invalid token, server tries to write the response multiple times, first with 403 header and later with 404 header because clusterId is missing. This PR changes so that response is sent only once (after the error is handled)