### PR TITLE
Set GITHUB_TOKEN as env variable for autotag action

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,7 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: butlerlogic/action-autotag@stable
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           strategy: package
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           tag_prefix: "v"


### PR DESCRIPTION
> The GITHUB_TOKEN must be provided. Without this, it is not possible to create a new tag. Make sure the autotag action looks like the following example:
```
- uses: butlerlogic/action-autotag@stable
  env:
    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
```

https://github.com/ButlerLogic/action-autotag?tab=readme-ov-file#configuration