### PR TITLE
Pin butlerlogic/action-autotag to 1.1.2

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: butlerlogic/action-autotag@stable
+      - uses: butlerlogic/action-autotag@1.1.2
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:


### PR DESCRIPTION
We are seeing the following error on build logs:
```
/app/node_modules/undici/lib/handler/RetryHandler.js:29
    } = retryOptions ?? {}
                      ^

SyntaxError: Unexpected token '?'
    at Object.compileFunction (vm.js:344:18)
    at wrapSafe (internal/modules/cjs/loader.js:[10](https://github.com/lensapp/bored/actions/runs/7638201227/job/20808593680#step:4:11)48:15)
    at Module._compile (internal/modules/cjs/loader.js:1082:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:[11](https://github.com/lensapp/bored/actions/runs/7638201227/job/20808593680#step:4:12)38:10)
    at Module.load (internal/modules/cjs/loader.js:982:32)
    at Function.Module._load (internal/modules/cjs/loader.js:875:[14](https://github.com/lensapp/bored/actions/runs/7638201227/job/20808593680#step:4:15))
    at Module.require (internal/modules/cjs/loader.js:1022:19)
    at require (internal/modules/cjs/helpers.js:72:[18](https://github.com/lensapp/bored/actions/runs/7638201227/job/20808593680#step:4:19))
    at Object.<anonymous> (/app/node_modules/undici/index.js:18:[22](https://github.com/lensapp/bored/actions/runs/7638201227/job/20808593680#step:4:23))
    at Module._compile (internal/modules/cjs/loader.js:1118:30)
```
This PR pins `butlerlogic/action-autotag` to version 1.1.2. This is a temporary workaround suggested in https://github.com/ButlerLogic/action-autotag/issues/46