### PR TITLE
feat: add server name to sentry init

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,10 @@ import { captureException, initExceptionHandler } from "./src/error-reporter";
 process.title = "bored";
 console.log(`~~ BoreD v${version} ~~`);
 
-initExceptionHandler();
+
+const tunnelAddress = process.env.TUNNEL_ADDRESS || "";
+
+initExceptionHandler(tunnelAddress);
 
 const serverPort = parseInt(process.env.PORT || "8080");
 const agentToken = process.env.AGENT_TOKEN || "";
@@ -35,4 +38,4 @@ process.once("SIGINT", () => {
   process.exit(0);
 });
 
-server.start(serverPort, agentToken, idpPublicKey);
+server.start(serverPort, agentToken, idpPublicKey, tunnelAddress);

--- a/src/error-reporter.ts
+++ b/src/error-reporter.ts
@@ -2,11 +2,12 @@ import * as Sentry from "@sentry/node";
 
 let enabled = false;
 
-export function initExceptionHandler() {
+export function initExceptionHandler(tunnelAddress: string) {
   if (process.env.SENTRY_DSN) {
     enabled = true;
     Sentry.init({
-      dsn: process.env.SENTRY_DSN
+      dsn: process.env.SENTRY_DSN,
+      serverName: tunnelAddress
     });
     console.log("ERROR-REPORTER: reporting enabled");
   }


### PR DESCRIPTION
* https://docs.sentry.io/platforms/java/configuration/options/#server-name
* Makes it easier to link the Sentry errors to the actual server