### PR TITLE
chore: remove unnecessary capture exception

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -50,7 +50,6 @@ export class Agent {
     stream.on("error", error => {
       console.error(error);
       this.clients.forEach((client) => this.removeClient(client.socket));
-      captureException(error);
     });
 
     this.mplex.on("error", error => {


### PR DESCRIPTION
A stream created from a WebSocket can emit an error when the WebSocket is in readyState of `CLOSING` but data is tried to be written. Here `BoredMplexClient` was used to pipe data from the Duplex stream (created from the Websocket). bored already handles these errors, so sending them as `captureException` is unnecessary and confusing. We should only capture unhandled or unexpected errors and send them to Sentry.